### PR TITLE
Statically tie to a specific API version of Vulkan

### DIFF
--- a/vk_initlib.cpp
+++ b/vk_initlib.cpp
@@ -375,7 +375,7 @@ bool vulkanCreateContext(VkDevice &device, VkPhysicalDevice& physicalDevice,  Vk
   VkApplicationInfo applicationInfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
   applicationInfo.pApplicationName = appTitle;
   applicationInfo.pEngineName = engineName;
-  applicationInfo.apiVersion = VK_API_VERSION;
+  applicationInfo.apiVersion = VK_MAKE_VERSION(1, 0, 4);
 
   // global layers and extensions
   const vector<VkLayerProperties> globalLayerProperties = GetGlobalLayerProperties();


### PR DESCRIPTION
Set the compatibility of this sample to a specific version of the Vulkan API to avoid driver incompatibilities with future Vulkan API releases.

The latest NVIDIA driver with Vulkan support (364.51) only supports Vulkan 1.0.4. This sample will fail if Vulkan 1.0.5 or greater is installed. Since this sample is expected to be compiled often in many environments, a static apiVersion would be more appropriate than the macro VK_API_VERSION.
